### PR TITLE
Upgrade to hadoop-3.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY ssh_config /etc/ssh/ssh_config
 WORKDIR /home/hduser
 
 USER hduser
-RUN wget -q https://downloads.apache.org/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz && tar zxvf hadoop-3.3.0.tar.gz && rm hadoop-3.3.0.tar.gz
+RUN wget -q https://downloads.apache.org/hadoop/common/hadoop-3.3.3/hadoop-3.3.3.tar.gz && tar zxvf hadoop-3.3.3.tar.gz && rm hadoop-3.3.3.tar.gz
 RUN ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa && cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys
 
 ENV HDFS_NAMENODE_USER hduser
@@ -18,7 +18,7 @@ ENV HDFS_SECONDARYNAMENODE_USER hduser
 ENV YARN_RESOURCEMANAGER_USER hduser
 ENV YARN_NODEMANAGER_USER hduser
 
-ENV HADOOP_HOME /home/hduser/hadoop-3.3.0
+ENV HADOOP_HOME /home/hduser/hadoop-3.3.3
 RUN echo "export JAVA_HOME=/usr" >> $HADOOP_HOME/etc/hadoop/hadoop-env.sh
 COPY core-site.xml $HADOOP_HOME/etc/hadoop/
 COPY hdfs-site.xml $HADOOP_HOME/etc/hadoop/
@@ -32,4 +32,4 @@ ADD examples/ examples/
 
 EXPOSE 50070 50075 50010 50020 50090 8020 9000 9864 9870 10020 19888 8088 8030 8031 8032 8033 8040 8042 22
 
-ENTRYPOINT ["/home/hduser/hadoop-3.3.0/etc/hadoop/docker-entrypoint.sh"]
+ENTRYPOINT ["/home/hduser/hadoop-3.3.3/etc/hadoop/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Copy the input files into the distributed filesystem:
 
 Run some of the examples provided:
 
-     hduser@localhost:~$ hadoop jar $HADOOP_HOME/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.3.0.jar grep input output 'dfs[a-z.]+'
+     hduser@localhost:~$ hadoop jar $HADOOP_HOME/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.3.3.jar grep input output 'dfs[a-z.]+'
 
      2020-08-08 01:57:02,411 INFO impl.MetricsConfig: Loaded properties from hadoop-metrics2.properties
      2020-08-08 01:57:04,754 INFO impl.MetricsSystemImpl: Scheduled Metric snapshot period at 10 second(s).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
-
 sudo service ssh start
-
 if [ ! -d "/tmp/hadoop-hduser/dfs/name" ]; then
         $HADOOP_HOME/bin/hdfs namenode -format
 fi
-
 $HADOOP_HOME/sbin/start-dfs.sh
 $HADOOP_HOME/sbin/start-yarn.sh
-
 bash


### PR DESCRIPTION
docker file downloads and installs hadoop 3.3.3
tests (hdfs + yarn grep) described in the README have been run successfully 